### PR TITLE
Fixed class for mittelaltschwuchtel

### DIFF
--- a/eckdaten.html
+++ b/eckdaten.html
@@ -29,7 +29,7 @@ user_titles:
     color: 5bb91c
   -
     name: Mittelaltschwuchtel
-    css: um11
+    css: um10
     color: addc8d
   -
     name: Wichtel


### PR DESCRIPTION
Sorry, that kinda slipped through...
Classes are the same as on Pr0gramm. 
This PR fixes the dot color for mittelaltschwuchtel, my bad. 